### PR TITLE
Update dependencies and refactor notification handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,5 @@ src/main/resources/json/
 /.idea/modules.xml
 /.idea/
 /.idea/misc.xml
-/.codex
+.codex/*
 null/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ screenshots when UI changes are involved.
 
 ## Configuration & Runtime Notes
 
-Java 21 is required. Desktop notifications are handled through `two-slices`; keep any notification backend changes
-documented in the README and the "Acerca de" dialog.
+Java 21 is required. Desktop notifications are handled through `two-slices`, using `dbus-java` for the Linux D-Bus
+backend; keep any notification backend changes documented in the README and the "Acerca de" dialog.
 Linux native packaging uses explicit `--linux-package-deps` alternatives to improve compatibility between Ubuntu 22.04
 and 24.04+.
 The release pipeline also dispatches Linux `.deb` metadata to the external APT repository updater; keep required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.7.14
+
+- Refactoriza las notificaciones de escritorio con `ToastBuilder` y un `DesktopNotifier` inyectable, eliminando la
+  copia del icono a directorios temporales y manteniendo fallback a diálogo Swing si falla el backend.
+- Asegura que las notificaciones inicialicen siempre `two-slices` con el nombre real de la aplicación, el icono de la
+  aplicación y el backend D-Bus en Linux, incluso cuando se muestran antes de una llamada explícita a `Growls.init()`.
+- Actualiza dependencias de mantenimiento: `com.sshtools:two-slices` a `0.9.7`,
+  `com.github.hypfvieh:dbus-java-*` a `5.2.0` y `org.junit.jupiter:junit-jupiter` a `6.1.1`.
+- Documenta `dbus-java` en el README y en el diálogo "Acerca de".
+- Mejora la testabilidad de `Ventana` extrayendo la comprobación asíncrona de nuevas versiones a métodos
+  package-private, y amplía la cobertura de condiciones para resultados positivos, negativos, nulos, errores e
+  interrupciones.
+- Refuerza utilidades internas evitando la instanciación de `UtilidadesFecha`.
+
 ## 2.7.13
 
 - Actualiza `io.github.jcprieto:loteria-navidad` a `6.0.12`.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Después, las nuevas versiones se reciben con:
   * Jackson https://github.com/FasterXML/jackson-core/wiki
   * GitHub Releases https://docs.github.com/es/repositories/releasing-projects-on-github/about-releases
   * two-slices https://github.com/sshtools/two-slices
+  * dbus-java https://github.com/hypfvieh/dbus-java
 
 ### Changelog ###
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>es.jklabs.desktop</groupId>
     <artifactId>LoteriaDeNavidad</artifactId>
-    <version>2.7.13</version>
+    <version>2.7.14</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.1.0</version>
+            <version>6.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.sshtools</groupId>
             <artifactId>two-slices</artifactId>
-            <version>0.9.6</version>
+            <version>0.9.7</version>
         </dependency>
         <dependency>
             <groupId>com.github.hypfvieh</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <mockito.version>5.23.0</mockito.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <dbus.java.version>4.3.1</dbus.java.version>
+        <dbus.java.version>5.2.0</dbus.java.version>
         <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
         <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
         <linux.package.deps>libasound2 | libasound2t64, libbrotli1, libbsd0, libbz2-1.0, libc6, libfreetype6, libgcc-s1,

--- a/src/main/java/es/jklabs/desktop/gui/Ventana.java
+++ b/src/main/java/es/jklabs/desktop/gui/Ventana.java
@@ -45,9 +45,13 @@ public class Ventana extends JFrame implements ActionListener {
 
     public void actionPerformed(final ActionEvent evt) {
         if (evt.getSource() == acerca) {
-            final AcercaDe dialogo = new AcercaDe(this);
+            final AcercaDe dialogo = crearDialogoAcercaDe();
             dialogo.setVisible(true);
         }
+    }
+
+    AcercaDe crearDialogoAcercaDe() {
+        return new AcercaDe(this);
     }
 
     private void crearMenu() {
@@ -64,27 +68,38 @@ public class Ventana extends JFrame implements ActionListener {
     }
 
     private void consultarNuevaVersionAsync() {
-        SwingWorker<Boolean, Void> worker = new SwingWorker<>() {
+        crearWorkerNuevaVersion().execute();
+    }
+
+    SwingWorker<Boolean, Void> crearWorkerNuevaVersion() {
+        return new SwingWorker<>() {
             @Override
             protected Boolean doInBackground() throws Exception {
-                return UtilidadesGitHubReleases.existeNuevaVersion();
+                return existeNuevaVersion();
             }
 
             @Override
             protected void done() {
-                try {
-                    if (Objects.equals(get(), Boolean.TRUE)) {
-                        agregarItemActualizacion();
-                    }
-                } catch (InterruptedException e) {
-                    Logger.error("consultar.nueva.version", e);
-                    Thread.currentThread().interrupt();
-                } catch (Exception e) {
-                    Logger.error("consultar.nueva.version", e);
-                }
+                procesarResultadoNuevaVersion(this::get);
             }
         };
-        worker.execute();
+    }
+
+    boolean existeNuevaVersion() throws Exception {
+        return UtilidadesGitHubReleases.existeNuevaVersion();
+    }
+
+    void procesarResultadoNuevaVersion(NuevaVersionResult result) {
+        try {
+            if (Objects.equals(result.get(), Boolean.TRUE)) {
+                agregarItemActualizacion();
+            }
+        } catch (InterruptedException e) {
+            Logger.error("consultar.nueva.version", e);
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            Logger.error("consultar.nueva.version", e);
+        }
     }
 
     private void agregarItemActualizacion() {
@@ -120,6 +135,11 @@ public class Ventana extends JFrame implements ActionListener {
     public void setPanelInferior(PanelInferior panelInferior) {
         this.panelInferior = panelInferior;
         super.add(panelInferior, BorderLayout.SOUTH);
+    }
+
+    @FunctionalInterface
+    interface NuevaVersionResult {
+        Boolean get() throws Exception;
     }
 
 }

--- a/src/main/java/es/jklabs/desktop/gui/dialogos/AcercaDe.java
+++ b/src/main/java/es/jklabs/desktop/gui/dialogos/AcercaDe.java
@@ -81,6 +81,7 @@ public class AcercaDe extends JDialog implements ActionListener {
         addPowered(panel, cns, yPosition++, "Jackson", "https://github.com/FasterXML/jackson-core/wiki");
         addPowered(panel, cns, yPosition++, "GitHub Releases", "https://docs.github.com/es/repositories/releasing-projects-on-github/about-releases");
         addPowered(panel, cns, yPosition++, "two-slices", "https://github.com/sshtools/two-slices");
+        addPowered(panel, cns, yPosition++, "dbus-java", "https://github.com/hypfvieh/dbus-java");
         JLabel jLabelLicense = new JLabel(
                 Mensajes.getMensaje("licencia.app"),
                 IconUtils.loadIcon("gplv3-with-text-136x68.png"), SwingConstants.CENTER);

--- a/src/main/java/es/jklabs/gui/utilidades/Growls.java
+++ b/src/main/java/es/jklabs/gui/utilidades/Growls.java
@@ -14,18 +14,23 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Locale;
+import java.util.Set;
 
 public class Growls {
 
     private static final String APP_ICON_NAME = "loteriadenavidad";
+    private static final String APP_DATA_DIR_NAME = ".loteriadenavidad";
     private static final String DBUS_TOASTER_CLASS = "com.sshtools.twoslices.impl.DBUSNotifyToaster";
     private static DialogDisplayer dialogDisplayer = Growls::showDialogInternal;
     private static ToastSender toastSender = Growls::showToastInternal;
     private static SettingsConfigurer settingsConfigurer = Growls::configureSettingsInternal;
     private static boolean settingsConfigured;
     private static Path appIconPath;
+    private static Path appIconDirectory;
 
     private Growls() {
 
@@ -70,6 +75,13 @@ public class Growls {
         toastSender = Growls::showToastInternal;
         settingsConfigurer = Growls::configureSettingsInternal;
         settingsConfigured = false;
+        appIconPath = null;
+        appIconDirectory = null;
+    }
+
+    static void setAppIconDirectoryForTests(Path directory) {
+        appIconDirectory = directory;
+        appIconPath = null;
     }
 
     private static void showDialogInternal(String titulo, String mensaje, int tipo) {
@@ -121,14 +133,43 @@ public class Growls {
             return APP_ICON_NAME;
         }
         try (InputStream in = iconUrl.openStream()) {
-            Path iconPath = Files.createTempFile(APP_ICON_NAME + "-", ".png");
+            Path iconDirectory = prepareAppIconDirectory();
+            Path iconPath = iconDirectory.resolve(APP_ICON_NAME + ".png");
+            if (Files.isSymbolicLink(iconPath)) {
+                throw new IOException("Toast icon path must not be a symbolic link: " + iconPath);
+            }
             Files.copy(in, iconPath, StandardCopyOption.REPLACE_EXISTING);
-            iconPath.toFile().deleteOnExit();
             appIconPath = iconPath;
             return iconPath.toAbsolutePath().toString();
         } catch (IOException e) {
             Logger.error(e);
             return APP_ICON_NAME;
+        }
+    }
+
+    private static Path getAppIconDirectory() {
+        if (appIconDirectory != null) {
+            return appIconDirectory;
+        }
+        return Paths.get(System.getProperty("user.home", "."), APP_DATA_DIR_NAME);
+    }
+
+    private static Path prepareAppIconDirectory() throws IOException {
+        Path iconDirectory = getAppIconDirectory();
+        if (Files.isSymbolicLink(iconDirectory)) {
+            throw new IOException("Toast icon directory must not be a symbolic link: " + iconDirectory);
+        }
+        Files.createDirectories(iconDirectory);
+        restrictDirectoryPermissions(iconDirectory);
+        return iconDirectory;
+    }
+
+    private static void restrictDirectoryPermissions(Path directory) throws IOException {
+        if (Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+            Files.setPosixFilePermissions(directory, Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE));
         }
     }
 

--- a/src/main/java/es/jklabs/gui/utilidades/Growls.java
+++ b/src/main/java/es/jklabs/gui/utilidades/Growls.java
@@ -1,45 +1,44 @@
 package es.jklabs.gui.utilidades;
 
-import com.sshtools.twoslices.Toast;
-import com.sshtools.twoslices.ToastType;
-import com.sshtools.twoslices.ToasterFactory;
-import com.sshtools.twoslices.ToasterSettings;
+import com.sshtools.twoslices.*;
 import es.jklabs.utilidades.Constantes;
 import es.jklabs.utilidades.Logger;
 import es.jklabs.utilidades.Mensajes;
 
 import javax.swing.*;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.PosixFilePermission;
 import java.util.Locale;
-import java.util.Set;
 
 public class Growls {
 
-    private static final String APP_ICON_NAME = "loteriadenavidad";
-    private static final String APP_DATA_DIR_NAME = ".loteriadenavidad";
     private static final String DBUS_TOASTER_CLASS = "com.sshtools.twoslices.impl.DBUSNotifyToaster";
+    private static DesktopNotifier notifier = new TwoSlicesDesktopNotifier();
     private static DialogDisplayer dialogDisplayer = Growls::showDialogInternal;
-    private static ToastSender toastSender = Growls::showToastInternal;
-    private static SettingsConfigurer settingsConfigurer = Growls::configureSettingsInternal;
-    private static boolean settingsConfigured;
-    private static Path appIconPath;
-    private static Path appIconDirectory;
+    private static URL notificationIcon = getNotificationIcon();
+    private static boolean initialized;
 
     private Growls() {
 
     }
 
+    public static void init() {
+        notificationIcon = getNotificationIcon();
+        ToasterSettings settings = new ToasterSettings()
+                .setAppName(Constantes.NOMBRE_APP);
+        if (notificationIcon != null) {
+            settings.setDefaultImage(notificationIcon);
+        }
+        if (isLinux()) {
+            settings.setPreferredToasterClassName(DBUS_TOASTER_CLASS);
+        }
+        ToasterFactory.setSettings(settings);
+        ToasterFactory.setFactory(null);
+        initialized = true;
+    }
+
     public static void mostrarInfo(String titulo, String cuerpo) {
         String tituloResuelto = titulo != null ? Mensajes.getMensaje(titulo) : Constantes.NOMBRE_APP;
-        String mensaje = Mensajes.getMensaje(cuerpo);
-        mostrarToast(tituloResuelto, mensaje, ToastType.INFO, JOptionPane.INFORMATION_MESSAGE);
+        mostrarGrowl(tituloResuelto, Mensajes.getMensaje(cuerpo), NotificationType.INFO);
     }
 
     public static void mostrarError(String cuerpo, Exception e) {
@@ -49,132 +48,77 @@ public class Growls {
     public static void mostrarError(String titulo, String cuerpo, Exception e) {
         String tituloResuelto = titulo != null ? Mensajes.getMensaje(titulo) : Constantes.NOMBRE_APP;
         String mensaje = Mensajes.getError(cuerpo);
-        mostrarToast(tituloResuelto, mensaje, ToastType.ERROR, JOptionPane.ERROR_MESSAGE);
+        mostrarGrowl(tituloResuelto, mensaje, NotificationType.ERROR);
         Logger.error(cuerpo, e);
     }
 
-    public static void init() {
-        configureSettings();
+    private static void mostrarGrowl(String titulo, String cuerpo, NotificationType type) {
+        try {
+            ensureInitialized();
+            notifier.show(titulo, cuerpo, type, notificationIcon);
+        } catch (RuntimeException e) {
+            Logger.error(e);
+            dialogDisplayer.show(titulo, cuerpo, type.optionPaneMessageType());
+        }
     }
 
-    static void setDialogDisplayerForTests(DialogDisplayer displayer) {
-        dialogDisplayer = displayer == null ? Growls::showDialogInternal : displayer;
+    private static void ensureInitialized() {
+        if (!initialized) {
+            init();
+        }
     }
 
-    static void setToastSenderForTests(ToastSender sender) {
-        toastSender = sender == null ? Growls::showToastInternal : sender;
-    }
-
-    static void setSettingsConfigurerForTests(SettingsConfigurer configurer) {
-        settingsConfigurer = configurer == null ? Growls::configureSettingsInternal : configurer;
-        settingsConfigured = false;
-    }
-
-    static void resetTestHooks() {
-        dialogDisplayer = Growls::showDialogInternal;
-        toastSender = Growls::showToastInternal;
-        settingsConfigurer = Growls::configureSettingsInternal;
-        settingsConfigured = false;
-        appIconPath = null;
-        appIconDirectory = null;
-    }
-
-    static void setAppIconDirectoryForTests(Path directory) {
-        appIconDirectory = directory;
-        appIconPath = null;
+    private static URL getNotificationIcon() {
+        return Growls.class.getResource("/img/icons/app/icon.png");
     }
 
     private static void showDialogInternal(String titulo, String mensaje, int tipo) {
         SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(null, mensaje, titulo, tipo));
     }
 
-    private static void mostrarToast(String titulo, String mensaje, ToastType toastType, int dialogType) {
-        try {
-            configureSettings();
-            toastSender.show(toastType, titulo, mensaje, getToastIcon());
-        } catch (RuntimeException e) {
-            Logger.error(e);
-            dialogDisplayer.show(titulo, mensaje, dialogType);
-        }
+    static void setNotifierForTests(DesktopNotifier notifier) {
+        Growls.notifier = notifier == null ? new TwoSlicesDesktopNotifier() : notifier;
     }
 
-    private static void showToastInternal(ToastType tipo, String titulo, String mensaje, String icono) {
-        Toast.toast(tipo, icono, titulo, mensaje);
+    static void setDialogDisplayerForTests(DialogDisplayer displayer) {
+        dialogDisplayer = displayer == null ? Growls::showDialogInternal : displayer;
     }
 
-    private static synchronized void configureSettings() {
-        if (!settingsConfigured) {
-            settingsConfigurer.configure();
-            settingsConfigured = true;
-        }
-    }
-
-    private static void configureSettingsInternal() {
-        ToasterSettings settings = new ToasterSettings()
-                .setAppName(Constantes.NOMBRE_APP)
-                .setDefaultImage(getAppIconUrl());
-        if (isLinux()) {
-            settings.setPreferredToasterClassName(DBUS_TOASTER_CLASS);
-        }
-        ToasterFactory.setSettings(settings);
-        ToasterFactory.setFactory(null);
-    }
-
-    private static URL getAppIconUrl() {
-        return Growls.class.getClassLoader().getResource("img/icons/app/icon.png");
-    }
-
-    private static synchronized String getToastIcon() {
-        if (appIconPath != null) {
-            return appIconPath.toAbsolutePath().toString();
-        }
-        URL iconUrl = getAppIconUrl();
-        if (iconUrl == null) {
-            return APP_ICON_NAME;
-        }
-        try (InputStream in = iconUrl.openStream()) {
-            Path iconDirectory = prepareAppIconDirectory();
-            Path iconPath = iconDirectory.resolve(APP_ICON_NAME + ".png");
-            if (Files.isSymbolicLink(iconPath)) {
-                throw new IOException("Toast icon path must not be a symbolic link: " + iconPath);
-            }
-            Files.copy(in, iconPath, StandardCopyOption.REPLACE_EXISTING);
-            appIconPath = iconPath;
-            return iconPath.toAbsolutePath().toString();
-        } catch (IOException e) {
-            Logger.error(e);
-            return APP_ICON_NAME;
-        }
-    }
-
-    private static Path getAppIconDirectory() {
-        if (appIconDirectory != null) {
-            return appIconDirectory;
-        }
-        return Paths.get(System.getProperty("user.home", "."), APP_DATA_DIR_NAME);
-    }
-
-    private static Path prepareAppIconDirectory() throws IOException {
-        Path iconDirectory = getAppIconDirectory();
-        if (Files.isSymbolicLink(iconDirectory)) {
-            throw new IOException("Toast icon directory must not be a symbolic link: " + iconDirectory);
-        }
-        Files.createDirectories(iconDirectory);
-        restrictDirectoryPermissions(iconDirectory);
-        return iconDirectory;
-    }
-
-    private static void restrictDirectoryPermissions(Path directory) throws IOException {
-        if (Files.getFileStore(directory).supportsFileAttributeView("posix")) {
-            Files.setPosixFilePermissions(directory, Set.of(
-                    PosixFilePermission.OWNER_READ,
-                    PosixFilePermission.OWNER_WRITE,
-                    PosixFilePermission.OWNER_EXECUTE));
-        }
+    static void resetTestHooks() {
+        notifier = new TwoSlicesDesktopNotifier();
+        dialogDisplayer = Growls::showDialogInternal;
+        notificationIcon = getNotificationIcon();
+        initialized = false;
     }
 
     private static boolean isLinux() {
         return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux");
+    }
+
+    enum NotificationType {
+        INFO(ToastType.INFO, JOptionPane.INFORMATION_MESSAGE),
+        ERROR(ToastType.ERROR, JOptionPane.ERROR_MESSAGE);
+
+        private final ToastType toastType;
+        private final int optionPaneMessageType;
+
+        NotificationType(ToastType toastType, int optionPaneMessageType) {
+            this.toastType = toastType;
+            this.optionPaneMessageType = optionPaneMessageType;
+        }
+
+        private ToastType toastType() {
+            return toastType;
+        }
+
+        private int optionPaneMessageType() {
+            return optionPaneMessageType;
+        }
+    }
+
+    @FunctionalInterface
+    interface DesktopNotifier {
+        void show(String title, String body, NotificationType type, URL icon);
     }
 
     @FunctionalInterface
@@ -182,13 +126,17 @@ public class Growls {
         void show(String titulo, String mensaje, int tipo);
     }
 
-    @FunctionalInterface
-    interface ToastSender {
-        void show(ToastType tipo, String titulo, String mensaje, String icono);
-    }
-
-    @FunctionalInterface
-    interface SettingsConfigurer {
-        void configure();
+    private static class TwoSlicesDesktopNotifier implements DesktopNotifier {
+        @Override
+        public void show(String title, String body, NotificationType type, URL icon) {
+            ToastBuilder builder = Toast.builder()
+                    .type(type.toastType())
+                    .title(title)
+                    .content(body);
+            if (icon != null) {
+                builder.icon(icon);
+            }
+            builder.toast();
+        }
     }
 }

--- a/src/main/java/es/jklabs/utilidades/UtilidadesFecha.java
+++ b/src/main/java/es/jklabs/utilidades/UtilidadesFecha.java
@@ -5,6 +5,9 @@ import java.time.format.DateTimeFormatter;
 
 public class UtilidadesFecha {
 
+    private UtilidadesFecha() {
+    }
+
     public static String getHumanReadable(LocalDateTime time) {
         return time.format(DateTimeFormatter.ofPattern("dd-MM-yy HH:mm"));
     }

--- a/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
@@ -2,6 +2,7 @@ package es.jklabs.desktop.gui;
 
 import es.jklabs.desktop.gui.dialogos.AcercaDe;
 import es.jklabs.utilidades.BaseTest;
+import es.jklabs.utilidades.Logger;
 import es.jklabs.utilidades.Mensajes;
 import es.jklabs.utilidades.UtilidadesGitHubReleases;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,6 @@ import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
@@ -33,13 +33,6 @@ class VentanaTest extends BaseTest {
         Method method = target.getClass().getDeclaredMethod(methodName);
         method.setAccessible(true);
         method.invoke(target);
-    }
-
-    private static SwingWorker<?, ?> createNuevaVersionWorker(Ventana ventana) throws Exception {
-        Class<?> workerClass = Class.forName("es.jklabs.desktop.gui.Ventana$1");
-        Constructor<?> constructor = workerClass.getDeclaredConstructor(Ventana.class);
-        constructor.setAccessible(true);
-        return (SwingWorker<?, ?>) constructor.newInstance(ventana);
     }
 
     private static Object getField(Object target, String fieldName) throws Exception {
@@ -148,7 +141,7 @@ class VentanaTest extends BaseTest {
         try (MockedStatic<UtilidadesGitHubReleases> mocked = Mockito.mockStatic(UtilidadesGitHubReleases.class)) {
             mocked.when(UtilidadesGitHubReleases::existeNuevaVersion).thenReturn(true);
 
-            SwingWorker<?, ?> worker = createNuevaVersionWorker(ventana);
+            SwingWorker<?, ?> worker = ventana.crearWorkerNuevaVersion();
             worker.run();
 
             waitForCondition(() -> getFieldUnchecked(ventana, "itemActualizacion") != null);
@@ -164,7 +157,7 @@ class VentanaTest extends BaseTest {
         try (MockedStatic<UtilidadesGitHubReleases> mocked = Mockito.mockStatic(UtilidadesGitHubReleases.class)) {
             mocked.when(UtilidadesGitHubReleases::existeNuevaVersion).thenReturn(false);
 
-            SwingWorker<?, ?> worker = createNuevaVersionWorker(ventana);
+            SwingWorker<?, ?> worker = ventana.crearWorkerNuevaVersion();
             worker.run();
 
             flushEdt();
@@ -180,11 +173,75 @@ class VentanaTest extends BaseTest {
         try (MockedStatic<UtilidadesGitHubReleases> mocked = Mockito.mockStatic(UtilidadesGitHubReleases.class)) {
             mocked.when(UtilidadesGitHubReleases::existeNuevaVersion).thenThrow(new IOException("fallo"));
 
-            SwingWorker<?, ?> worker = createNuevaVersionWorker(ventana);
+            SwingWorker<?, ?> worker = ventana.crearWorkerNuevaVersion();
             worker.run();
 
             flushEdt();
             assertNull(getField(ventana, "itemActualizacion"));
+        }
+    }
+
+    @Test
+    void procesarResultadoNuevaVersionAniadeEntradaCuandoResultadoEsTrue() throws Exception {
+        Ventana ventana = createVentanaWithoutConstructor();
+        setField(ventana, "barraMenu", new JMenuBar());
+
+        ventana.procesarResultadoNuevaVersion(() -> Boolean.TRUE);
+
+        assertNotNull(getField(ventana, "itemActualizacion"));
+    }
+
+    @Test
+    void procesarResultadoNuevaVersionNoAniadeEntradaCuandoResultadoEsFalse() throws Exception {
+        Ventana ventana = createVentanaWithoutConstructor();
+        setField(ventana, "barraMenu", new JMenuBar());
+
+        ventana.procesarResultadoNuevaVersion(() -> Boolean.FALSE);
+
+        assertNull(getField(ventana, "itemActualizacion"));
+    }
+
+    @Test
+    void procesarResultadoNuevaVersionIgnoraResultadoNulo() throws Exception {
+        Ventana ventana = createVentanaWithoutConstructor();
+        setField(ventana, "barraMenu", new JMenuBar());
+
+        ventana.procesarResultadoNuevaVersion(() -> null);
+
+        assertNull(getField(ventana, "itemActualizacion"));
+    }
+
+    @Test
+    void procesarResultadoNuevaVersionRegistraExcepcionSinAniadirEntrada() throws Exception {
+        Ventana ventana = createVentanaWithoutConstructor();
+        setField(ventana, "barraMenu", new JMenuBar());
+        IOException exception = new IOException("fallo");
+
+        try (MockedStatic<Logger> mockedLogger = Mockito.mockStatic(Logger.class)) {
+            ventana.procesarResultadoNuevaVersion(() -> {
+                throw exception;
+            });
+
+            mockedLogger.verify(() -> Logger.error("consultar.nueva.version", exception));
+            assertNull(getField(ventana, "itemActualizacion"));
+        }
+    }
+
+    @Test
+    void procesarResultadoNuevaVersionRestauraInterrupcionSiConsultaSeInterrumpe() throws Exception {
+        Ventana ventana = createVentanaWithoutConstructor();
+        InterruptedException exception = new InterruptedException("interrumpido");
+        Thread.interrupted();
+
+        try (MockedStatic<Logger> mockedLogger = Mockito.mockStatic(Logger.class)) {
+            ventana.procesarResultadoNuevaVersion(() -> {
+                throw exception;
+            });
+
+            mockedLogger.verify(() -> Logger.error("consultar.nueva.version", exception));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
         }
     }
 

--- a/src/test/java/es/jklabs/desktop/gui/dialogos/AcercaDeTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/dialogos/AcercaDeTest.java
@@ -172,6 +172,23 @@ class AcercaDeTest extends BaseTest {
     }
 
     @Test
+    void addPoweredIncluyeDbusJavaComoLibreriaDeNotificaciones() throws Exception {
+        TestAcercaDe acercaDe = createDialogWithoutConstructor();
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints cns = new GridBagConstraints();
+
+        invokeAddPowered(acercaDe, panel, cns, 8, "dbus-java", "https://github.com/hypfvieh/dbus-java");
+
+        assertEquals(2, panel.getComponentCount());
+        JLabel titleLabel = (JLabel) panel.getComponent(0);
+        JLabel urlLabel = (JLabel) panel.getComponent(1);
+        assertEquals("<html><b>dbus-java</b></html>", titleLabel.getText());
+        assertEquals("https://github.com/hypfvieh/dbus-java", urlLabel.getText());
+        assertInstanceOf(UrlMouseListener.class, titleLabel.getMouseListeners()[0]);
+        assertInstanceOf(UrlMouseListener.class, urlLabel.getMouseListeners()[0]);
+    }
+
+    @Test
     void addPoweredAddsOnlyTitleWhenUrlIsNull() throws Exception {
         TestAcercaDe acercaDe = createDialogWithoutConstructor();
         GridBagLayout layout = new GridBagLayout();

--- a/src/test/java/es/jklabs/gui/utilidades/GrowlsTest.java
+++ b/src/test/java/es/jklabs/gui/utilidades/GrowlsTest.java
@@ -7,18 +7,33 @@ import es.jklabs.utilidades.BaseTest;
 import es.jklabs.utilidades.Constantes;
 import es.jklabs.utilidades.Mensajes;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.swing.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class GrowlsTest extends BaseTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path appIconDirectory;
+
+    @BeforeEach
+    void configureIconDirectory() {
+        appIconDirectory = tempDir.resolve("app-icons");
+        Growls.setAppIconDirectoryForTests(appIconDirectory);
+    }
 
     @AfterEach
     void resetHooks() {
@@ -181,6 +196,35 @@ class GrowlsTest extends BaseTest {
             Growls.setToastSenderForTests(null);
             Growls.setSettingsConfigurerForTests(null);
         });
+    }
+
+    @Test
+    void iconoDeToastSeCopiaEnDirectorioPrivadoDeAplicacion() {
+        AtomicReference<String> icono = new AtomicReference<>();
+        Growls.setToastSenderForTests((ty, t, m, i) -> icono.set(i));
+
+        Growls.mostrarInfo(null, "nueva.version.descargada");
+
+        Path iconPath = Path.of(icono.get());
+        assertEquals(appIconDirectory, iconPath.getParent());
+        assertEquals("loteriadenavidad.png", iconPath.getFileName().toString());
+        assertTrue(Files.isRegularFile(iconPath));
+    }
+
+    @Test
+    void directorioDeIconoUsaPermisosSoloDePropietarioCuandoHayPosix() throws Exception {
+        AtomicReference<String> icono = new AtomicReference<>();
+        Growls.setToastSenderForTests((ty, t, m, i) -> icono.set(i));
+
+        Growls.mostrarInfo(null, "nueva.version.descargada");
+
+        Path iconDirectory = Path.of(icono.get()).getParent();
+        if (Files.getFileStore(iconDirectory).supportsFileAttributeView("posix")) {
+            assertEquals(Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE), Files.getPosixFilePermissions(iconDirectory));
+        }
     }
 
     private void assertIconoAplicacion(String icono) {

--- a/src/test/java/es/jklabs/gui/utilidades/GrowlsTest.java
+++ b/src/test/java/es/jklabs/gui/utilidades/GrowlsTest.java
@@ -1,22 +1,16 @@
 package es.jklabs.gui.utilidades;
 
-import com.sshtools.twoslices.ToastType;
 import com.sshtools.twoslices.ToasterFactory;
 import com.sshtools.twoslices.ToasterSettings;
 import es.jklabs.utilidades.BaseTest;
 import es.jklabs.utilidades.Constantes;
 import es.jklabs.utilidades.Mensajes;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import javax.swing.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
+import java.net.URL;
 import java.util.Locale;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -24,32 +18,44 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class GrowlsTest extends BaseTest {
 
-    @TempDir
-    Path tempDir;
-
-    private Path appIconDirectory;
-
-    @BeforeEach
-    void configureIconDirectory() {
-        appIconDirectory = tempDir.resolve("app-icons");
-        Growls.setAppIconDirectoryForTests(appIconDirectory);
-    }
-
     @AfterEach
     void resetHooks() {
         Growls.resetTestHooks();
     }
 
     @Test
+    void initConfiguraTwoSlicesConNombreIconoYBackendLinux() {
+        Growls.init();
+
+        ToasterSettings settings = ToasterFactory.getSettings();
+
+        assertEquals(Constantes.NOMBRE_APP, settings.getAppName());
+        assertNotNull(settings.getDefaultImage());
+        if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux")) {
+            assertEquals("com.sshtools.twoslices.impl.DBUSNotifyToaster", settings.getPreferredToasterClassName());
+        }
+    }
+
+    @Test
+    void mostrarInfoConfiguraNombreDeAplicacionAunqueNoSeLlameInitAntes() {
+        AtomicReference<String> appName = new AtomicReference<>();
+        Growls.setNotifierForTests((t, m, ty, i) -> appName.set(ToasterFactory.getSettings().getAppName()));
+
+        Growls.mostrarInfo(null, "nueva.version.descargada");
+
+        assertEquals(Constantes.NOMBRE_APP, appName.get());
+    }
+
+    @Test
     void mostrarInfoUsaTwoSlicesConTituloPredeterminado() {
-        AtomicReference<ToastType> tipo = new AtomicReference<>();
+        AtomicReference<Growls.NotificationType> tipo = new AtomicReference<>();
         AtomicReference<String> titulo = new AtomicReference<>();
         AtomicReference<String> mensaje = new AtomicReference<>();
-        AtomicReference<String> icono = new AtomicReference<>();
-        Growls.setToastSenderForTests((ty, t, m, i) -> {
-            tipo.set(ty);
+        AtomicReference<URL> icono = new AtomicReference<>();
+        Growls.setNotifierForTests((t, m, ty, i) -> {
             titulo.set(t);
             mensaje.set(m);
+            tipo.set(ty);
             icono.set(i);
         });
         Growls.setDialogDisplayerForTests((t, m, ty) -> {
@@ -58,16 +64,16 @@ class GrowlsTest extends BaseTest {
 
         Growls.mostrarInfo(null, "nueva.version.descargada");
 
-        assertEquals(ToastType.INFO, tipo.get());
+        assertEquals(Growls.NotificationType.INFO, tipo.get());
         assertEquals(Constantes.NOMBRE_APP, titulo.get());
         assertEquals(Mensajes.getMensaje("nueva.version.descargada"), mensaje.get());
-        assertIconoAplicacion(icono.get());
+        assertNotNull(icono.get());
     }
 
     @Test
     void mostrarInfoUsaTwoSlicesConTituloTraducido() {
         AtomicReference<String> titulo = new AtomicReference<>();
-        Growls.setToastSenderForTests((ty, t, m, i) -> titulo.set(t));
+        Growls.setNotifierForTests((t, m, ty, i) -> titulo.set(t));
 
         Growls.mostrarInfo("app.titulo", "nueva.version.descargada");
 
@@ -80,7 +86,7 @@ class GrowlsTest extends BaseTest {
         AtomicReference<String> mensaje = new AtomicReference<>();
         AtomicReference<Integer> tipo = new AtomicReference<>();
         AtomicInteger llamadas = new AtomicInteger();
-        Growls.setToastSenderForTests((ty, t, m, i) -> {
+        Growls.setNotifierForTests((t, m, ty, i) -> {
             throw new IllegalStateException("notificaciones no disponibles");
         });
         Growls.setDialogDisplayerForTests((t, m, ty) -> {
@@ -100,29 +106,29 @@ class GrowlsTest extends BaseTest {
 
     @Test
     void mostrarErrorUsaTwoSlicesConTituloPredeterminado() {
-        AtomicReference<ToastType> tipo = new AtomicReference<>();
+        AtomicReference<Growls.NotificationType> tipo = new AtomicReference<>();
         AtomicReference<String> titulo = new AtomicReference<>();
         AtomicReference<String> mensaje = new AtomicReference<>();
-        AtomicReference<String> icono = new AtomicReference<>();
-        Growls.setToastSenderForTests((ty, t, m, i) -> {
-            tipo.set(ty);
+        AtomicReference<URL> icono = new AtomicReference<>();
+        Growls.setNotifierForTests((t, m, ty, i) -> {
             titulo.set(t);
             mensaje.set(m);
+            tipo.set(ty);
             icono.set(i);
         });
 
         Growls.mostrarError("descargar.nueva.version", new RuntimeException("boom"));
 
-        assertEquals(ToastType.ERROR, tipo.get());
+        assertEquals(Growls.NotificationType.ERROR, tipo.get());
         assertEquals(Constantes.NOMBRE_APP, titulo.get());
         assertEquals(Mensajes.getError("descargar.nueva.version"), mensaje.get());
-        assertIconoAplicacion(icono.get());
+        assertNotNull(icono.get());
     }
 
     @Test
     void mostrarErrorUsaTwoSlicesConTituloTraducido() {
         AtomicReference<String> titulo = new AtomicReference<>();
-        Growls.setToastSenderForTests((ty, t, m, i) -> titulo.set(t));
+        Growls.setNotifierForTests((t, m, ty, i) -> titulo.set(t));
 
         Growls.mostrarError("app.titulo", "descargar.nueva.version", new RuntimeException("boom"));
 
@@ -135,7 +141,7 @@ class GrowlsTest extends BaseTest {
         AtomicReference<String> mensaje = new AtomicReference<>();
         AtomicReference<Integer> tipo = new AtomicReference<>();
         AtomicInteger llamadas = new AtomicInteger();
-        Growls.setToastSenderForTests((ty, t, m, i) -> {
+        Growls.setNotifierForTests((t, m, ty, i) -> {
             throw new IllegalStateException("notificaciones no disponibles");
         });
         Growls.setDialogDisplayerForTests((t, m, ty) -> {
@@ -154,82 +160,10 @@ class GrowlsTest extends BaseTest {
     }
 
     @Test
-    void initConfiguraNotificaciones() {
-        AtomicInteger llamadas = new AtomicInteger();
-        Growls.setSettingsConfigurerForTests(llamadas::incrementAndGet);
-
-        Growls.init();
-
-        assertEquals(1, llamadas.get());
-    }
-
-    @Test
-    void mostrarInfoConfiguraNotificacionesAntesDeMostrarToast() {
-        AtomicInteger configuraciones = new AtomicInteger();
-        AtomicInteger notificaciones = new AtomicInteger();
-        Growls.setSettingsConfigurerForTests(configuraciones::incrementAndGet);
-        Growls.setToastSenderForTests((ty, t, m, i) -> notificaciones.incrementAndGet());
-
-        Growls.mostrarInfo(null, "nueva.version.descargada");
-
-        assertEquals(1, configuraciones.get());
-        assertEquals(1, notificaciones.get());
-    }
-
-    @Test
-    void initConfiguraTwoSlicesConNombreIconoYBackendLinux() {
-        Growls.init();
-
-        ToasterSettings settings = ToasterFactory.getSettings();
-
-        assertEquals(Constantes.NOMBRE_APP, settings.getAppName());
-        assertNotNull(settings.getDefaultImage());
-        if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux")) {
-            assertEquals("com.sshtools.twoslices.impl.DBUSNotifyToaster", settings.getPreferredToasterClassName());
-        }
-    }
-
-    @Test
     void settersDePruebaRestauranImplementacionesPredeterminadasConNull() {
         assertDoesNotThrow(() -> {
+            Growls.setNotifierForTests(null);
             Growls.setDialogDisplayerForTests(null);
-            Growls.setToastSenderForTests(null);
-            Growls.setSettingsConfigurerForTests(null);
         });
-    }
-
-    @Test
-    void iconoDeToastSeCopiaEnDirectorioPrivadoDeAplicacion() {
-        AtomicReference<String> icono = new AtomicReference<>();
-        Growls.setToastSenderForTests((ty, t, m, i) -> icono.set(i));
-
-        Growls.mostrarInfo(null, "nueva.version.descargada");
-
-        Path iconPath = Path.of(icono.get());
-        assertEquals(appIconDirectory, iconPath.getParent());
-        assertEquals("loteriadenavidad.png", iconPath.getFileName().toString());
-        assertTrue(Files.isRegularFile(iconPath));
-    }
-
-    @Test
-    void directorioDeIconoUsaPermisosSoloDePropietarioCuandoHayPosix() throws Exception {
-        AtomicReference<String> icono = new AtomicReference<>();
-        Growls.setToastSenderForTests((ty, t, m, i) -> icono.set(i));
-
-        Growls.mostrarInfo(null, "nueva.version.descargada");
-
-        Path iconDirectory = Path.of(icono.get()).getParent();
-        if (Files.getFileStore(iconDirectory).supportsFileAttributeView("posix")) {
-            assertEquals(Set.of(
-                    PosixFilePermission.OWNER_READ,
-                    PosixFilePermission.OWNER_WRITE,
-                    PosixFilePermission.OWNER_EXECUTE), Files.getPosixFilePermissions(iconDirectory));
-        }
-    }
-
-    private void assertIconoAplicacion(String icono) {
-        assertNotNull(icono);
-        assertTrue(icono.endsWith(".png"));
-        assertTrue(Files.isRegularFile(Path.of(icono)));
     }
 }


### PR DESCRIPTION
Bump version to 2.7.14, refactor desktop notification handling with `ToastBuilder` and injectable `DesktopNotifier`, document `dbus-java`, update dependencies, improve `Ventana` testability, and enhance internal utilities.