### PR TITLE
Bump jackson-databind to 2.22.1 and improve exception handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ After introducing code changes, review and run the unit tests for the modified c
 proceeding. Whenever a new public class or public method is added, implement its corresponding unit test.
 For Swing panels, create components on the EDT (`SwingUtilities.invokeAndWait`) and stop any active `Timer` in tests
 to avoid cross-test interference from background refreshes.
+For asynchronous waits in tests, prefer Awaitility over `Thread.sleep()`; keep EDT flushes inside the awaited condition
+when the code under test completes through Swing callbacks.
 For Swing components that launch asynchronous work and create external collaborators (network/services), prefer adding
 minimal package-private or overridable factory methods so tests can inject mocks without depending on live I/O.
 For utility classes that perform direct HTTP calls, prefer package-private test hooks such as connection factories so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.7.15
+
+- Actualiza `com.fasterxml.jackson.core:jackson-databind` a `2.22.1`.
+- Ajusta la comprobación asíncrona de nuevas versiones en `Ventana` para declarar excepciones más específicas
+  (`IOException`, `ExecutionException` e `InterruptedException`) sin cambiar el comportamiento público.
+- Incorpora `org.awaitility:awaitility` como dependencia de test y reemplaza la espera manual con `Thread.sleep()` en
+  `VentanaTest`, evitando issues de SonarQube y manteniendo la sincronización con el EDT.
+- Simplifica helpers internos de `VentanaTest` centrados en la entrada de actualización y mantiene la cobertura de los
+  flujos de nueva versión, errores e interrupciones.
+
 ## 2.7.14
 
 - Refactoriza las notificaciones de escritorio con `ToastBuilder` y un `DesktopNotifier` inyectable, eliminando la

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         </linux.package.deps>
         <sonar.organization>jcprieto</sonar.organization>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-        <surefireArgLine></surefireArgLine>
+        <surefireArgLine/>
     </properties>
 
     <dependencies>
@@ -39,6 +39,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>es.jklabs.desktop</groupId>
     <artifactId>LoteriaDeNavidad</artifactId>
-    <version>2.7.14</version>
+    <version>2.7.15</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/es/jklabs/desktop/gui/Ventana.java
+++ b/src/main/java/es/jklabs/desktop/gui/Ventana.java
@@ -13,6 +13,7 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.IOException;
 import java.io.Serial;
 import java.util.Objects;
 
@@ -85,7 +86,7 @@ public class Ventana extends JFrame implements ActionListener {
         };
     }
 
-    boolean existeNuevaVersion() throws Exception {
+    boolean existeNuevaVersion() throws IOException {
         return UtilidadesGitHubReleases.existeNuevaVersion();
     }
 

--- a/src/main/java/es/jklabs/desktop/gui/Ventana.java
+++ b/src/main/java/es/jklabs/desktop/gui/Ventana.java
@@ -16,6 +16,7 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.io.Serial;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 
 /**
  * @author juanky
@@ -140,7 +141,7 @@ public class Ventana extends JFrame implements ActionListener {
 
     @FunctionalInterface
     interface NuevaVersionResult {
-        Boolean get() throws Exception;
+        Boolean get() throws ExecutionException, InterruptedException;
     }
 
 }

--- a/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
@@ -17,6 +17,7 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -216,13 +217,14 @@ class VentanaTest extends BaseTest {
         Ventana ventana = createVentanaWithoutConstructor();
         setField(ventana, "barraMenu", new JMenuBar());
         IOException exception = new IOException("fallo");
+        ExecutionException executionException = new ExecutionException(exception);
 
         try (MockedStatic<Logger> mockedLogger = Mockito.mockStatic(Logger.class)) {
             ventana.procesarResultadoNuevaVersion(() -> {
-                throw exception;
+                throw executionException;
             });
 
-            mockedLogger.verify(() -> Logger.error("consultar.nueva.version", exception));
+            mockedLogger.verify(() -> Logger.error("consultar.nueva.version", executionException));
             assertNull(getField(ventana, "itemActualizacion"));
         }
     }

--- a/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
@@ -17,8 +17,11 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 class VentanaTest extends BaseTest {
@@ -30,21 +33,21 @@ class VentanaTest extends BaseTest {
         return (Ventana) unsafe.allocateInstance(Ventana.class);
     }
 
-    private static void invokePrivate(Object target, String methodName) throws Exception {
-        Method method = target.getClass().getDeclaredMethod(methodName);
+    private static void invokePrivate(Object target) throws Exception {
+        Method method = target.getClass().getDeclaredMethod("agregarItemActualizacion");
         method.setAccessible(true);
         method.invoke(target);
     }
 
-    private static Object getField(Object target, String fieldName) throws Exception {
-        Field field = target.getClass().getDeclaredField(fieldName);
+    private static Object getField(Object target) throws Exception {
+        Field field = target.getClass().getDeclaredField("itemActualizacion");
         field.setAccessible(true);
         return field.get(target);
     }
 
-    private static Object getFieldUnchecked(Object target, String fieldName) {
+    private static Object getFieldUnchecked(Object target) {
         try {
-            return getField(target, fieldName);
+            return getField(target);
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
@@ -56,16 +59,15 @@ class VentanaTest extends BaseTest {
         field.set(target, value);
     }
 
-    private static void waitForCondition(Condition condition) throws Exception {
-        long deadline = System.currentTimeMillis() + 3000;
-        while (System.currentTimeMillis() < deadline) {
-            flushEdt();
-            if (condition.matches()) {
-                return;
-            }
-            Thread.sleep(25);
-        }
-        fail("Condition was not met before timeout");
+    private static void waitForCondition(Callable<Boolean> condition) {
+        await()
+                .pollInSameThread()
+                .atMost(Duration.ofSeconds(3))
+                .pollInterval(Duration.ofMillis(25))
+                .until(() -> {
+                    flushEdt();
+                    return condition.call();
+                });
     }
 
     private static void flushEdt() throws Exception {
@@ -83,7 +85,7 @@ class VentanaTest extends BaseTest {
             ventana.actionPerformed(new ActionEvent(acerca, ActionEvent.ACTION_PERFORMED, "click"));
 
             assertEquals(1, mocked.constructed().size());
-            Mockito.verify(mocked.constructed().get(0)).setVisible(true);
+            Mockito.verify(mocked.constructed().getFirst()).setVisible(true);
         }
     }
 
@@ -105,9 +107,9 @@ class VentanaTest extends BaseTest {
         JMenuBar barraMenu = new JMenuBar();
         setField(ventana, "barraMenu", barraMenu);
 
-        invokePrivate(ventana, "agregarItemActualizacion");
+        invokePrivate(ventana);
 
-        JMenuItem itemActualizacion = (JMenuItem) getField(ventana, "itemActualizacion");
+        JMenuItem itemActualizacion = (JMenuItem) getField(ventana);
         assertNotNull(itemActualizacion);
         assertEquals(Mensajes.getMensaje("menu.nueva.version"), itemActualizacion.getText());
         assertEquals(2, barraMenu.getComponentCount());
@@ -128,9 +130,9 @@ class VentanaTest extends BaseTest {
         setField(ventana, "barraMenu", barraMenu);
         setField(ventana, "itemActualizacion", existente);
 
-        invokePrivate(ventana, "agregarItemActualizacion");
+        invokePrivate(ventana);
 
-        assertSame(existente, getField(ventana, "itemActualizacion"));
+        assertSame(existente, getField(ventana));
         assertEquals(0, barraMenu.getComponentCount());
     }
 
@@ -145,8 +147,8 @@ class VentanaTest extends BaseTest {
             SwingWorker<?, ?> worker = ventana.crearWorkerNuevaVersion();
             worker.run();
 
-            waitForCondition(() -> getFieldUnchecked(ventana, "itemActualizacion") != null);
-            assertNotNull(getField(ventana, "itemActualizacion"));
+            waitForCondition(() -> getFieldUnchecked(ventana) != null);
+            assertNotNull(getField(ventana));
         }
     }
 
@@ -162,7 +164,7 @@ class VentanaTest extends BaseTest {
             worker.run();
 
             flushEdt();
-            assertNull(getField(ventana, "itemActualizacion"));
+            assertNull(getField(ventana));
         }
     }
 
@@ -178,7 +180,7 @@ class VentanaTest extends BaseTest {
             worker.run();
 
             flushEdt();
-            assertNull(getField(ventana, "itemActualizacion"));
+            assertNull(getField(ventana));
         }
     }
 
@@ -189,7 +191,7 @@ class VentanaTest extends BaseTest {
 
         ventana.procesarResultadoNuevaVersion(() -> Boolean.TRUE);
 
-        assertNotNull(getField(ventana, "itemActualizacion"));
+        assertNotNull(getField(ventana));
     }
 
     @Test
@@ -199,7 +201,7 @@ class VentanaTest extends BaseTest {
 
         ventana.procesarResultadoNuevaVersion(() -> Boolean.FALSE);
 
-        assertNull(getField(ventana, "itemActualizacion"));
+        assertNull(getField(ventana));
     }
 
     @Test
@@ -209,7 +211,7 @@ class VentanaTest extends BaseTest {
 
         ventana.procesarResultadoNuevaVersion(() -> null);
 
-        assertNull(getField(ventana, "itemActualizacion"));
+        assertNull(getField(ventana));
     }
 
     @Test
@@ -225,7 +227,7 @@ class VentanaTest extends BaseTest {
             });
 
             mockedLogger.verify(() -> Logger.error("consultar.nueva.version", executionException));
-            assertNull(getField(ventana, "itemActualizacion"));
+            assertNull(getField(ventana));
         }
     }
 
@@ -247,8 +249,4 @@ class VentanaTest extends BaseTest {
         }
     }
 
-    @FunctionalInterface
-    private interface Condition {
-        boolean matches();
-    }
 }


### PR DESCRIPTION
## 2.7.15

- Actualiza `com.fasterxml.jackson.core:jackson-databind` a `2.22.1`.
- Ajusta la comprobación asíncrona de nuevas versiones en `Ventana` para declarar excepciones más específicas
  (`IOException`, `ExecutionException` e `InterruptedException`) sin cambiar el comportamiento público.
- Incorpora `org.awaitility:awaitility` como dependencia de test y reemplaza la espera manual con `Thread.sleep()` en
  `VentanaTest`, evitando issues de SonarQube y manteniendo la sincronización con el EDT.
- Simplifica helpers internos de `VentanaTest` centrados en la entrada de actualización y mantiene la cobertura de los
  flujos de nueva versión, errores e interrupciones.