### PR TITLE
Update dependencies and improve test readability and efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.7.16
+
+- Actualiza `io.github.jcprieto:loteria-navidad` de `6.0.12` a `7.0.0`.
+- Actualiza dependencias de test: `org.junit.jupiter:junit-jupiter` a `6.1.2` y
+  `org.awaitility:awaitility` a `4.3.0`.
+- Mejora la testabilidad de `ResumenNavidad` mediante una factoría de `Conexion` sobreescribible y amplía su cobertura
+  para el refresco correcto, respuestas nulas, errores del servicio, actualizaciones concurrentes y ciclo de vida del
+  `Timer`.
+- Sustituye la espera manual con `Thread.sleep()` en `MenuPrincipalTest` por Awaitility con sincronización del EDT y
+  simplifica varios tests Swing mediante imports estáticos, referencias a métodos y helpers más específicos.
+
 ## 2.7.15
 
 - Actualiza `com.fasterxml.jackson.core:jackson-databind` a `2.22.1`.

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.2</version>
+            <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>io.github.jcprieto</groupId>
             <artifactId>loteria-navidad</artifactId>
-            <version>6.0.12</version>
+            <version>7.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>es.jklabs.desktop</groupId>
     <artifactId>LoteriaDeNavidad</artifactId>
-    <version>2.7.15</version>
+    <version>2.7.16</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/es/jklabs/desktop/gui/paneles/ResumenNavidad.java
+++ b/src/main/java/es/jklabs/desktop/gui/paneles/ResumenNavidad.java
@@ -64,7 +64,7 @@ public class ResumenNavidad extends JPanel implements ActionListener {
         SwingWorker<io.github.jcprieto.lib.loteria.model.navidad.ResumenNavidad, Void> worker = new SwingWorker<>() {
             @Override
             protected io.github.jcprieto.lib.loteria.model.navidad.ResumenNavidad doInBackground() throws IOException {
-                final Conexion con = new Conexion();
+                final Conexion con = crearConexion();
                 return con.getResumenNavidad();
             }
 
@@ -95,6 +95,10 @@ public class ResumenNavidad extends JPanel implements ActionListener {
             }
         };
         worker.execute();
+    }
+
+    Conexion crearConexion() {
+        return new Conexion();
     }
 
     @Override

--- a/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/VentanaTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 
 class VentanaTest extends BaseTest {
 
@@ -85,7 +86,7 @@ class VentanaTest extends BaseTest {
             ventana.actionPerformed(new ActionEvent(acerca, ActionEvent.ACTION_PERFORMED, "click"));
 
             assertEquals(1, mocked.constructed().size());
-            Mockito.verify(mocked.constructed().getFirst()).setVisible(true);
+            verify(mocked.constructed().getFirst()).setVisible(true);
         }
     }
 

--- a/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
@@ -153,7 +153,7 @@ class MenuPrincipalTest extends BaseTest {
         clickEnEdt(panel.getBtnBuscarPremioNavidadForTests());
 
         InOrder inOrder = Mockito.inOrder(ventana);
-        inOrder.verify(ventana).setPanel(Mockito.argThat(p -> p instanceof PanelBusqueda));
+        inOrder.verify(ventana).setPanel(Mockito.argThat(PanelBusqueda.class::isInstance));
         inOrder.verify(ventana).setPanelInferior(Mockito.argThat(Objects::nonNull));
         inOrder.verify(ventana).pack();
     }
@@ -166,7 +166,7 @@ class MenuPrincipalTest extends BaseTest {
         clickEnEdt(panel.getBtnBuscarPremioNinoForTests());
 
         InOrder inOrder = Mockito.inOrder(ventana);
-        inOrder.verify(ventana).setPanel(Mockito.argThat(p -> p instanceof PanelBusqueda));
+        inOrder.verify(ventana).setPanel(Mockito.argThat(PanelBusqueda.class::isInstance));
         inOrder.verify(ventana).setPanelInferior(Mockito.argThat(Objects::nonNull));
         inOrder.verify(ventana).pack();
     }

--- a/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MenuPrincipalTest extends BaseTest {
 
@@ -210,7 +211,7 @@ class MenuPrincipalTest extends BaseTest {
     void clickEnResumenNavidadMuestraResumenCuandoHayDatos() throws Exception {
         Ventana ventana = mock(Ventana.class);
         MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
-        Mockito.when(resumenService.getResumenNavidad()).thenReturn(crearResumenNavidad());
+        when(resumenService.getResumenNavidad()).thenReturn(crearResumenNavidad());
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
         clickEnEdt(panel.getBtnResumenNavidadForTests());
@@ -230,7 +231,7 @@ class MenuPrincipalTest extends BaseTest {
     void clickEnResumenNinoMuestraResumenCuandoHayDatos() throws Exception {
         Ventana ventana = mock(Ventana.class);
         MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
-        Mockito.when(resumenService.getResumenNino()).thenReturn(crearResumenNino());
+        when(resumenService.getResumenNino()).thenReturn(crearResumenNino());
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
         clickEnEdt(panel.getBtnResumenNinoForTests());
@@ -250,7 +251,7 @@ class MenuPrincipalTest extends BaseTest {
     void clickEnResumenNavidadMuestraAvisoCuandoNoHayDatos() throws Exception {
         Ventana ventana = mock(Ventana.class);
         MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
-        Mockito.when(resumenService.getResumenNavidad()).thenReturn(null);
+        when(resumenService.getResumenNavidad()).thenReturn(null);
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
         clickEnEdt(panel.getBtnResumenNavidadForTests());
@@ -266,7 +267,7 @@ class MenuPrincipalTest extends BaseTest {
     void clickEnResumenNinoMuestraAvisoCuandoNoHayDatos() throws Exception {
         Ventana ventana = mock(Ventana.class);
         MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
-        Mockito.when(resumenService.getResumenNino()).thenReturn(null);
+        when(resumenService.getResumenNino()).thenReturn(null);
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
         clickEnEdt(panel.getBtnResumenNinoForTests());
@@ -282,7 +283,7 @@ class MenuPrincipalTest extends BaseTest {
     void clickEnResumenNavidadMuestraAvisoCuandoFallaElServicio() throws Exception {
         Ventana ventana = mock(Ventana.class);
         MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
-        Mockito.when(resumenService.getResumenNavidad()).thenThrow(new IOException("boom"));
+        when(resumenService.getResumenNavidad()).thenThrow(new IOException("boom"));
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
         clickEnEdt(panel.getBtnResumenNavidadForTests());
@@ -297,7 +298,7 @@ class MenuPrincipalTest extends BaseTest {
     void clickEnResumenNinoMuestraAvisoCuandoFallaElServicio() throws Exception {
         Ventana ventana = mock(Ventana.class);
         MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
-        Mockito.when(resumenService.getResumenNino()).thenThrow(new IOException("boom"));
+        when(resumenService.getResumenNino()).thenThrow(new IOException("boom"));
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
         clickEnEdt(panel.getBtnResumenNinoForTests());

--- a/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
@@ -21,8 +21,7 @@ import java.util.Objects;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class MenuPrincipalTest extends BaseTest {
 
@@ -258,7 +257,7 @@ class MenuPrincipalTest extends BaseTest {
         esperarCarga(panel);
 
         assertEquals(Mensajes.getMensaje(MenuPrincipal.WARNING_PROBLEMA_SERVIDOR), panel.getLastWarningForTests());
-        Mockito.verify(resumenService).getResumenNavidad();
+        verify(resumenService).getResumenNavidad();
         Mockito.verifyNoInteractions(ventana);
         assertTrue(panel.getBtnResumenNavidadForTests().isEnabled());
     }
@@ -274,7 +273,7 @@ class MenuPrincipalTest extends BaseTest {
         esperarCarga(panel);
 
         assertEquals(Mensajes.getMensaje(MenuPrincipal.WARNING_PROBLEMA_SERVIDOR), panel.getLastWarningForTests());
-        Mockito.verify(resumenService).getResumenNino();
+        verify(resumenService).getResumenNino();
         Mockito.verifyNoInteractions(ventana);
         assertTrue(panel.getBtnResumenNinoForTests().isEnabled());
     }
@@ -290,7 +289,7 @@ class MenuPrincipalTest extends BaseTest {
         esperarCarga(panel);
 
         assertEquals(Mensajes.getMensaje(MenuPrincipal.WARNING_PROBLEMA_SERVIDOR), panel.getLastWarningForTests());
-        Mockito.verify(resumenService).getResumenNavidad();
+        verify(resumenService).getResumenNavidad();
         Mockito.verifyNoInteractions(ventana);
     }
 
@@ -305,7 +304,7 @@ class MenuPrincipalTest extends BaseTest {
         esperarCarga(panel);
 
         assertEquals(Mensajes.getMensaje(MenuPrincipal.WARNING_PROBLEMA_SERVIDOR), panel.getLastWarningForTests());
-        Mockito.verify(resumenService).getResumenNino();
+        verify(resumenService).getResumenNino();
         Mockito.verifyNoInteractions(ventana);
     }
 

--- a/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
@@ -15,6 +15,7 @@ import java.awt.event.ActionEvent;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import java.util.Objects;
 
@@ -76,7 +77,7 @@ class MenuPrincipalTest extends BaseTest {
         resumen.setCuarto(List.of("33333", "44444"));
         resumen.setQuinto(List.of("55555", "66666"));
         resumen.setEstado(EstadoSorteo.TERMINADO);
-        resumen.setFechaActualizacion(LocalDateTime.of(2025, 12, 22, 14, 0));
+        resumen.setFechaActualizacion(LocalDateTime.of(2025, Month.DECEMBER, 22, 14, 0));
         resumen.setUrlPDF("https://example.com/navidad.pdf");
         return resumen;
     }

--- a/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
@@ -13,10 +13,12 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MenuPrincipalTest extends BaseTest {
@@ -44,14 +46,17 @@ class MenuPrincipalTest extends BaseTest {
                 new ActionEvent(source, ActionEvent.ACTION_PERFORMED, "cmd")));
     }
 
-    private static void esperarCarga(MenuPrincipal panel) throws Exception {
-        long deadline = System.currentTimeMillis() + 3000;
-        while (System.currentTimeMillis() < deadline && !panel.getBtnResumenNavidadForTests().isEnabled()) {
-            Thread.sleep(20);
-        }
-        SwingUtilities.invokeAndWait(() -> {
-            // Drena el EDT para ejecutar el done del SwingWorker.
-        });
+    private static void esperarCarga(MenuPrincipal panel) {
+        await()
+                .pollInSameThread()
+                .atMost(Duration.ofSeconds(3))
+                .pollInterval(Duration.ofMillis(20))
+                .until(() -> {
+                    SwingUtilities.invokeAndWait(() -> {
+                        // Drena el EDT para ejecutar el done del SwingWorker.
+                    });
+                    return panel.getBtnResumenNavidadForTests().isEnabled();
+                });
     }
 
     private static <T> T crearEnEdt(EdtSupplier<T> supplier) throws Exception {

--- a/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 class MenuPrincipalTest extends BaseTest {
 
@@ -100,7 +101,7 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void creaBotonesConTextoEsperado() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         MenuPrincipal panel = crearEnEdt(() -> new MenuPrincipal(ventana));
 
         JButton btnResumenNavidad = obtenerBoton(panel, "btnResumenNavidad");
@@ -121,7 +122,7 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void deshabilitaBotonesMientrasCarga() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         MenuPrincipal panel = crearEnEdt(() -> new MenuPrincipal(ventana));
 
         JButton btnResumenNavidad = obtenerBoton(panel, "btnResumenNavidad");
@@ -146,7 +147,7 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnBuscarNavidadMuestraPanelBusqueda() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         MenuPrincipal panel = crearEnEdt(() -> new MenuPrincipal(ventana));
 
         clickEnEdt(panel.getBtnBuscarPremioNavidadForTests());
@@ -159,7 +160,7 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnBuscarNinoMuestraPanelBusqueda() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         MenuPrincipal panel = crearEnEdt(() -> new MenuPrincipal(ventana));
 
         clickEnEdt(panel.getBtnBuscarPremioNinoForTests());
@@ -172,8 +173,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void ignoraEventosDeOrigenDesconocido() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         MenuPrincipal panel = crearEnEdt(() -> new MenuPrincipal(ventana, resumenService));
 
         ejecutarEventoEnEdt(panel, new JButton("otro"));
@@ -183,8 +184,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void ignoraResumenNavidadSiYaEstaCargando() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         MenuPrincipal panel = crearEnEdt(() -> new MenuPrincipal(ventana, resumenService));
 
         invocarSetCargando(panel, true);
@@ -195,8 +196,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void ignoraResumenNinoSiYaEstaCargando() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         MenuPrincipal panel = crearEnEdt(() -> new MenuPrincipal(ventana, resumenService));
 
         invocarSetCargando(panel, true);
@@ -207,8 +208,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnResumenNavidadMuestraResumenCuandoHayDatos() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         Mockito.when(resumenService.getResumenNavidad()).thenReturn(crearResumenNavidad());
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
@@ -227,8 +228,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnResumenNinoMuestraResumenCuandoHayDatos() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         Mockito.when(resumenService.getResumenNino()).thenReturn(crearResumenNino());
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
@@ -247,8 +248,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnResumenNavidadMuestraAvisoCuandoNoHayDatos() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         Mockito.when(resumenService.getResumenNavidad()).thenReturn(null);
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
@@ -263,8 +264,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnResumenNinoMuestraAvisoCuandoNoHayDatos() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         Mockito.when(resumenService.getResumenNino()).thenReturn(null);
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
@@ -279,8 +280,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnResumenNavidadMuestraAvisoCuandoFallaElServicio() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         Mockito.when(resumenService.getResumenNavidad()).thenThrow(new IOException("boom"));
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 
@@ -294,8 +295,8 @@ class MenuPrincipalTest extends BaseTest {
 
     @Test
     void clickEnResumenNinoMuestraAvisoCuandoFallaElServicio() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
-        MenuPrincipal.ResumenService resumenService = Mockito.mock(MenuPrincipal.ResumenService.class);
+        Ventana ventana = mock(Ventana.class);
+        MenuPrincipal.ResumenService resumenService = mock(MenuPrincipal.ResumenService.class);
         Mockito.when(resumenService.getResumenNino()).thenThrow(new IOException("boom"));
         TestMenuPrincipal panel = crearEnEdt(() -> new TestMenuPrincipal(ventana, resumenService));
 

--- a/src/test/java/es/jklabs/desktop/gui/paneles/ResumenNavidadTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/ResumenNavidadTest.java
@@ -8,17 +8,19 @@ import es.jklabs.utilidades.UtilidadesFecha;
 import io.github.jcprieto.lib.loteria.conexion.Conexion;
 import io.github.jcprieto.lib.loteria.enumeradores.EstadoSorteo;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ResumenNavidadTest extends BaseTest {
@@ -70,6 +72,17 @@ class ResumenNavidadTest extends BaseTest {
         });
     }
 
+    private static void esperarHastaQueFinaliceActualizacion(ResumenNavidad panel) {
+        await()
+                .pollInSameThread()
+                .atMost(Duration.ofSeconds(3))
+                .pollInterval(Duration.ofMillis(25))
+                .until(() -> {
+                    esperarEdt();
+                    return !getBooleanField(panel);
+                });
+    }
+
     private static JLabel getLabel(ResumenNavidad panel, String fieldName) throws Exception {
         return (JLabel) getField(panel, fieldName);
     }
@@ -84,14 +97,14 @@ class ResumenNavidadTest extends BaseTest {
         return timer;
     }
 
-    private static boolean getBooleanField(ResumenNavidad panel, String fieldName) throws Exception {
-        return (boolean) getField(panel, fieldName);
+    private static boolean getBooleanField(ResumenNavidad panel) throws Exception {
+        return (boolean) getField(panel, "actualizando");
     }
 
-    private static void setBooleanField(ResumenNavidad panel, String fieldName, boolean value) throws Exception {
-        Field field = ResumenNavidad.class.getDeclaredField(fieldName);
+    private static void setBooleanField(ResumenNavidad panel) throws Exception {
+        Field field = ResumenNavidad.class.getDeclaredField("actualizando");
         field.setAccessible(true);
-        field.setBoolean(panel, value);
+        field.setBoolean(panel, true);
     }
 
     private static void detenerTimer(ResumenNavidad panel) throws Exception {
@@ -120,6 +133,12 @@ class ResumenNavidadTest extends BaseTest {
         Field field = ResumenNavidad.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         return field.get(panel);
+    }
+
+    private static ResumenNavidad crearPanel(Ventana ventana,
+                                             io.github.jcprieto.lib.loteria.model.navidad.ResumenNavidad resumen,
+                                             Conexion conexion) throws Exception {
+        return crearEnEdt(() -> new ResumenNavidadTestable(ventana, resumen, conexion));
     }
 
     @Test
@@ -161,13 +180,15 @@ class ResumenNavidadTest extends BaseTest {
     @Test
     void ignoraEventosQueNoVienenDelTimer() throws Exception {
         Ventana ventana = Mockito.mock(Ventana.class);
-        ResumenNavidad panel = crearEnEdt(() -> new ResumenNavidad(ventana, crearResumenBase()));
+        Conexion conexion = Mockito.mock(Conexion.class);
+        ResumenNavidad panel = crearPanel(ventana, crearResumenBase(), conexion);
         try {
             panel.actionPerformed(new ActionEvent(new JButton("otro"), ActionEvent.ACTION_PERFORMED, "cmd"));
             esperarEdt();
 
             Mockito.verifyNoInteractions(ventana);
-            assertFalse(getBooleanField(panel, "actualizando"));
+            Mockito.verifyNoInteractions(conexion);
+            assertFalse(getBooleanField(panel));
         } finally {
             detenerTimer(panel);
         }
@@ -179,6 +200,12 @@ class ResumenNavidadTest extends BaseTest {
         ResumenNavidad panel = crearEnEdt(() -> new ResumenNavidad(ventana, crearResumenBase()));
         Timer timer = getTimer(panel);
         try {
+            SwingUtilities.invokeAndWait(panel::addNotify);
+            assertTrue(timer.isRunning());
+
+            SwingUtilities.invokeAndWait(panel::removeNotify);
+            assertFalse(timer.isRunning());
+
             SwingUtilities.invokeAndWait(panel::removeNotify);
             assertFalse(timer.isRunning());
 
@@ -214,15 +241,115 @@ class ResumenNavidadTest extends BaseTest {
     @Test
     void ignoraTickDelTimerSiYaHayUnaActualizacionEnCurso() throws Exception {
         Ventana ventana = Mockito.mock(Ventana.class);
-        ResumenNavidad panel = crearEnEdt(() -> new ResumenNavidad(ventana, crearResumenBase()));
-        try (MockedConstruction<Conexion> mocked = Mockito.mockConstruction(Conexion.class)) {
-            setBooleanField(panel, "actualizando", true);
+        Conexion conexion = Mockito.mock(Conexion.class);
+        ResumenNavidad panel = crearPanel(ventana, crearResumenBase(), conexion);
+        try {
+            setBooleanField(panel);
 
             panel.actionPerformed(new ActionEvent(getTimer(panel), ActionEvent.ACTION_PERFORMED, "tick"));
             esperarEdt();
 
-            assertTrue(getBooleanField(panel, "actualizando"));
-            assertEquals(0, mocked.constructed().size());
+            assertTrue(getBooleanField(panel));
+            Mockito.verifyNoInteractions(conexion);
+            Mockito.verifyNoInteractions(ventana);
+        } finally {
+            detenerTimer(panel);
+        }
+    }
+
+    @Test
+    void actualizaResumenCuandoConexionDevuelveDatos() throws Exception {
+        Ventana ventana = Mockito.mock(Ventana.class);
+        Conexion conexion = Mockito.mock(Conexion.class);
+        ResumenNavidad panel = crearPanel(ventana, crearResumenBase(), conexion);
+        io.github.jcprieto.lib.loteria.model.navidad.ResumenNavidad actualizado = crearResumen(
+                "99999", "88888", "77777",
+                List.of("12345", "54321"),
+                List.of("11111", "22222", "33333", "44444"),
+                EstadoSorteo.TERMINADO,
+                LocalDateTime.of(2026, 12, 22, 14, 30),
+                "https://example.test/final-navidad.pdf"
+        );
+
+        try {
+            Mockito.when(conexion.getResumenNavidad()).thenReturn(actualizado);
+            panel.actionPerformed(new ActionEvent(getTimer(panel), ActionEvent.ACTION_PERFORMED, "tick"));
+            esperarHastaQueFinaliceActualizacion(panel);
+
+            Mockito.verify(conexion).getResumenNavidad();
+            assertEquals("99999", getLabel(panel, "gordo").getText());
+            assertEquals("88888", getLabel(panel, "segundo").getText());
+            assertEquals("77777", getLabel(panel, "tercero").getText());
+            assertEquals(2, getPanel(panel, "panelCuarto").getComponentCount());
+            assertEquals(4, getPanel(panel, "panelQuinto").getComponentCount());
+            assertEquals(
+                    Mensajes.getMensaje("resumen.estado") + UtilidadesEstadoSorteo.getHumanReadable(EstadoSorteo.TERMINADO),
+                    getLabel(panel, "estado").getText()
+            );
+            assertEquals(
+                    Mensajes.getMensaje("resumen.actualizacion") + UtilidadesFecha.getHumanReadable(actualizado.getFechaActualizacion()),
+                    getLabel(panel, "actualizacion").getText()
+            );
+            assertEquals("https://example.test/final-navidad.pdf", getLabel(panel, "pdf").getText());
+            assertFalse(getBooleanField(panel));
+            Mockito.verify(ventana).pack();
+        } finally {
+            detenerTimer(panel);
+        }
+    }
+
+    @Test
+    void noActualizaPanelesSiConexionDevuelveNull() throws Exception {
+        Ventana ventana = Mockito.mock(Ventana.class);
+        Conexion conexion = Mockito.mock(Conexion.class);
+        ResumenNavidad panel = crearPanel(ventana, crearResumenBase(), conexion);
+        String gordoInicial = getLabel(panel, "gordo").getText();
+        String segundoInicial = getLabel(panel, "segundo").getText();
+        String terceroInicial = getLabel(panel, "tercero").getText();
+        int cuartoInicial = getPanel(panel, "panelCuarto").getComponentCount();
+        int quintoInicial = getPanel(panel, "panelQuinto").getComponentCount();
+        String estadoInicial = getLabel(panel, "estado").getText();
+        String actualizacionInicial = getLabel(panel, "actualizacion").getText();
+        String pdfInicial = getLabel(panel, "pdf").getText();
+
+        try {
+            Mockito.when(conexion.getResumenNavidad()).thenReturn(null);
+            panel.actionPerformed(new ActionEvent(getTimer(panel), ActionEvent.ACTION_PERFORMED, "tick"));
+            esperarHastaQueFinaliceActualizacion(panel);
+
+            Mockito.verify(conexion).getResumenNavidad();
+            assertEquals(gordoInicial, getLabel(panel, "gordo").getText());
+            assertEquals(segundoInicial, getLabel(panel, "segundo").getText());
+            assertEquals(terceroInicial, getLabel(panel, "tercero").getText());
+            assertEquals(cuartoInicial, getPanel(panel, "panelCuarto").getComponentCount());
+            assertEquals(quintoInicial, getPanel(panel, "panelQuinto").getComponentCount());
+            assertEquals(estadoInicial, getLabel(panel, "estado").getText());
+            assertEquals(actualizacionInicial, getLabel(panel, "actualizacion").getText());
+            assertEquals(pdfInicial, getLabel(panel, "pdf").getText());
+            assertFalse(getBooleanField(panel));
+            Mockito.verifyNoInteractions(ventana);
+        } finally {
+            detenerTimer(panel);
+        }
+    }
+
+    @Test
+    void reseteaEstadoDeActualizacionSiConexionFalla() throws Exception {
+        Ventana ventana = Mockito.mock(Ventana.class);
+        Conexion conexion = Mockito.mock(Conexion.class);
+        ResumenNavidad panel = crearPanel(ventana, crearResumenBase(), conexion);
+        String gordoInicial = getLabel(panel, "gordo").getText();
+        String pdfInicial = getLabel(panel, "pdf").getText();
+
+        try {
+            Mockito.when(conexion.getResumenNavidad()).thenThrow(new IOException("boom"));
+            panel.actionPerformed(new ActionEvent(getTimer(panel), ActionEvent.ACTION_PERFORMED, "tick"));
+            esperarHastaQueFinaliceActualizacion(panel);
+
+            Mockito.verify(conexion).getResumenNavidad();
+            assertEquals(gordoInicial, getLabel(panel, "gordo").getText());
+            assertEquals(pdfInicial, getLabel(panel, "pdf").getText());
+            assertFalse(getBooleanField(panel));
             Mockito.verifyNoInteractions(ventana);
         } finally {
             detenerTimer(panel);
@@ -231,5 +358,21 @@ class ResumenNavidadTest extends BaseTest {
 
     private interface EdtSupplier<T> {
         T get();
+    }
+
+    private static final class ResumenNavidadTestable extends ResumenNavidad {
+        private final Conexion conexion;
+
+        private ResumenNavidadTestable(Ventana ventana,
+                                       io.github.jcprieto.lib.loteria.model.navidad.ResumenNavidad resultado,
+                                       Conexion conexion) {
+            super(ventana, resultado);
+            this.conexion = conexion;
+        }
+
+        @Override
+        Conexion crearConexion() {
+            return conexion;
+        }
     }
 }


### PR DESCRIPTION
## 2.7.16

- Actualiza `io.github.jcprieto:loteria-navidad` de `6.0.12` a `7.0.0`.
- Actualiza dependencias de test: `org.junit.jupiter:junit-jupiter` a `6.1.2` y
  `org.awaitility:awaitility` a `4.3.0`.
- Mejora la testabilidad de `ResumenNavidad` mediante una factoría de `Conexion` sobreescribible y amplía su cobertura
  para el refresco correcto, respuestas nulas, errores del servicio, actualizaciones concurrentes y ciclo de vida del
  `Timer`.
- Sustituye la espera manual con `Thread.sleep()` en `MenuPrincipalTest` por Awaitility con sincronización del EDT y
  simplifica varios tests Swing mediante imports estáticos, referencias a métodos y helpers más específicos.