### PR TITLE
Bump maven-jar-plugin to 3.5.1 and address SonarQube issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.7.17
+
+- Actualiza `org.apache.maven.plugins:maven-jar-plugin` de `3.5.0` a `3.5.1`.
+- Amplía la cobertura de condiciones de `ResumenMouseListenerTest` para URI válidas, URL inválidas sin esquema, enlaces
+  sin ruta y la restauración del navegador usado en tests.
+- Sustituye la espera manual con `Thread.sleep()` en `PanelBusquedaTest` por Awaitility con sincronización del EDT,
+  haciendo que los bloqueos asíncronos fallen de forma determinista al alcanzar el timeout.
+- Resuelve incidencias de mantenibilidad de SonarQube en los tests mediante imports estáticos, visibilidad
+  package-private y el uso de `Month.JANUARY` en fechas de prueba.
+
 ## 2.7.16
 
 - Actualiza `io.github.jcprieto:loteria-navidad` de `6.0.12` a `7.0.0`.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>es.jklabs.desktop</groupId>
     <artifactId>LoteriaDeNavidad</artifactId>
-    <version>2.7.16</version>
+    <version>2.7.17</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/src/test/java/es/jklabs/desktop/gui/listener/ResumenMouseListenerTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/listener/ResumenMouseListenerTest.java
@@ -3,11 +3,12 @@ package es.jklabs.desktop.gui.listener;
 import es.jklabs.utilidades.BaseTest;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URISyntaxException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ResumenMouseListenerTest extends BaseTest {
 
@@ -15,6 +16,21 @@ class ResumenMouseListenerTest extends BaseTest {
         Method method = ResumenMouseListener.class.getDeclaredMethod("buildUri", String.class);
         method.setAccessible(true);
         return (URI) method.invoke(null, url);
+    }
+
+    private static URI invokeGetUri(String url, int schemeEnd) throws Exception {
+        Method method = ResumenMouseListener.class.getDeclaredMethod("getUri", String.class, int.class);
+        method.setAccessible(true);
+        return (URI) method.invoke(null, url, schemeEnd);
+    }
+
+    @Test
+    void buildUriReturnsValidUriWithoutRebuildingIt() throws Exception {
+        String url = "https://example.com/documento.pdf";
+
+        URI uri = invokeBuildUri(url);
+
+        assertEquals(url, uri.toString());
     }
 
     @Test
@@ -39,5 +55,33 @@ class ResumenMouseListenerTest extends BaseTest {
         assertEquals("/mi%20ruta/archivo.pdf", uri.getRawPath());
         assertEquals("tipo=lista%20oficial", uri.getRawQuery());
         assertEquals("seccion", uri.getRawFragment());
+    }
+
+    @Test
+    void buildUriRejectsInvalidUrlWithoutScheme() {
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class,
+                () -> invokeBuildUri("ruta con espacios/archivo.pdf"));
+
+        assertInstanceOf(URISyntaxException.class, exception.getCause());
+    }
+
+    @Test
+    void getUriSupportsUrlWithoutPath() throws Exception {
+        String url = "https://example.com";
+
+        URI uri = invokeGetUri(url, url.indexOf("://"));
+
+        assertEquals(url, uri.toString());
+        assertEquals("example.com", uri.getAuthority());
+        assertEquals("", uri.getPath());
+    }
+
+    @Test
+    void setBrowserForTestsAcceptsNull() throws Exception {
+        ResumenMouseListener.setBrowserForTests(null);
+
+        var browserField = ResumenMouseListener.class.getDeclaredField("browser");
+        browserField.setAccessible(true);
+        assertNotNull(browserField.get(null));
     }
 }

--- a/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/MenuPrincipalTest.java
@@ -94,7 +94,7 @@ class MenuPrincipalTest extends BaseTest {
         resumen.setDosCifras(List.of("33", "44"));
         resumen.setReintegros(List.of("3", "4"));
         resumen.setEstado(EstadoSorteo.TERMINADO);
-        resumen.setFechaActualizacion(LocalDateTime.of(2026, 1, 6, 14, 0));
+        resumen.setFechaActualizacion(LocalDateTime.of(2026, Month.JANUARY, 6, 14, 0));
         resumen.setUrlPDF("https://example.com/nino.pdf");
         return resumen;
     }

--- a/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class PanelBusquedaTest extends BaseTest {
 
@@ -235,7 +236,7 @@ class PanelBusquedaTest extends BaseTest {
         assertEquals(0, panel.getResultadoPanelForTests().getComponentCount());
         assertEquals("", panel.getNumeroFieldForTests().getText());
         assertEquals("", panel.getCantidadFieldForTests().getText());
-        Mockito.verify(ventana, Mockito.atLeastOnce()).pack();
+        verify(ventana, Mockito.atLeastOnce()).pack();
     }
 
     @Test

--- a/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 class PanelBusquedaTest extends BaseTest {
 
@@ -40,7 +41,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioAgregaResultadoCuandoExiste() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         PanelBusqueda.PremioService premioService = (sorteo, numero) -> {
             Premio premio = new Premio();
             premio.setCantidad(BigDecimal.valueOf(123.0));
@@ -60,7 +61,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioMuestraAvisoCuandoNoHayDatos() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         PanelBusqueda.PremioService premioService = (sorteo, numero) -> {
             Premio premio = new Premio();
             premio.setCantidad(BigDecimal.ZERO);
@@ -90,7 +91,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioMuestraAvisoCuandoPremioEsNull() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> null);
 
         panel.getNumeroFieldForTests().setText("12345");
@@ -104,7 +105,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioMuestraAvisoCuandoCantidadNoEsValida() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         AtomicInteger llamadas = new AtomicInteger();
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> {
             llamadas.incrementAndGet();
@@ -122,7 +123,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void parseCantidadAceptaSoloNumerosPositivos() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> new Premio());
 
         assertEquals(new BigDecimal("1.50"), panel.parseCantidad(" 1.50 "));
@@ -134,7 +135,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioConNumeroVacioNoHaceNada() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         AtomicInteger llamadas = new AtomicInteger();
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> {
             llamadas.incrementAndGet();
@@ -151,7 +152,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioIgnoraNuevaBusquedaMientrasHayUnaActiva() throws Exception {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         CountDownLatch servicioIniciado = new CountDownLatch(1);
         CountDownLatch liberarServicio = new CountDownLatch(1);
         AtomicInteger llamadas = new AtomicInteger();
@@ -184,7 +185,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioMuestraMensajeDeExcepcionDeDecimoNoDisponible() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         String mensaje = "El premio no esta disponible";
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> {
             throw new PremioDecimoNoDisponibleException(mensaje);
@@ -201,7 +202,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void buscarPremioMuestraAvisoGenericoCuandoServicioFalla() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> {
             throw new IOException("Sin conexion");
         });
@@ -217,7 +218,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void limpiarEliminaResultadosYCampos() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         PanelBusqueda.PremioService premioService = (sorteo, numero) -> {
             Premio premio = new Premio();
             premio.setCantidad(BigDecimal.TEN);
@@ -239,7 +240,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void filtroNumeroSoloPermiteDigitosBackspaceYMaximoCincoCaracteres() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> new Premio());
         JTextField numero = panel.getNumeroFieldForTests();
 
@@ -253,7 +254,7 @@ class PanelBusquedaTest extends BaseTest {
 
     @Test
     void filtroCantidadSoloPermiteDigitosYPunto() {
-        Ventana ventana = Mockito.mock(Ventana.class);
+        Ventana ventana = mock(Ventana.class);
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> new Premio());
         JTextField cantidad = panel.getCantidadFieldForTests();
 

--- a/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
@@ -15,26 +15,31 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PanelBusquedaTest extends BaseTest {
 
-    private static void waitForBusqueda(PanelBusqueda panel) throws Exception {
-        long deadline = System.currentTimeMillis() + 2000;
-        while (System.currentTimeMillis() < deadline && panel.isBuscandoForTests()) {
-            Thread.sleep(20);
-        }
-        SwingUtilities.invokeAndWait(() -> {
-            // Drena la cola del EDT para asegurar el done del SwingWorker
-        });
+    private static void waitForBusqueda(PanelBusqueda panel) {
+        await()
+                .pollInSameThread()
+                .atMost(Duration.ofSeconds(2))
+                .pollInterval(Duration.ofMillis(20))
+                .until(() -> {
+                    SwingUtilities.invokeAndWait(() -> {
+                        // Drena la cola del EDT para asegurar el done del SwingWorker
+                    });
+                    return !panel.isBuscandoForTests();
+                });
     }
 
     @Test
-    void buscarPremioAgregaResultadoCuandoExiste() throws Exception {
+    void buscarPremioAgregaResultadoCuandoExiste() {
         Ventana ventana = Mockito.mock(Ventana.class);
         PanelBusqueda.PremioService premioService = (sorteo, numero) -> {
             Premio premio = new Premio();
@@ -54,7 +59,7 @@ class PanelBusquedaTest extends BaseTest {
     }
 
     @Test
-    void buscarPremioMuestraAvisoCuandoNoHayDatos() throws Exception {
+    void buscarPremioMuestraAvisoCuandoNoHayDatos() {
         Ventana ventana = Mockito.mock(Ventana.class);
         PanelBusqueda.PremioService premioService = (sorteo, numero) -> {
             Premio premio = new Premio();
@@ -84,7 +89,7 @@ class PanelBusquedaTest extends BaseTest {
     }
 
     @Test
-    void buscarPremioMuestraAvisoCuandoPremioEsNull() throws Exception {
+    void buscarPremioMuestraAvisoCuandoPremioEsNull() {
         Ventana ventana = Mockito.mock(Ventana.class);
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> null);
 
@@ -178,7 +183,7 @@ class PanelBusquedaTest extends BaseTest {
     }
 
     @Test
-    void buscarPremioMuestraMensajeDeExcepcionDeDecimoNoDisponible() throws Exception {
+    void buscarPremioMuestraMensajeDeExcepcionDeDecimoNoDisponible() {
         Ventana ventana = Mockito.mock(Ventana.class);
         String mensaje = "El premio no esta disponible";
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> {
@@ -195,7 +200,7 @@ class PanelBusquedaTest extends BaseTest {
     }
 
     @Test
-    void buscarPremioMuestraAvisoGenericoCuandoServicioFalla() throws Exception {
+    void buscarPremioMuestraAvisoGenericoCuandoServicioFalla() {
         Ventana ventana = Mockito.mock(Ventana.class);
         TestPanelBusqueda panel = new TestPanelBusqueda(ventana, Sorteo.NAVIDAD, (sorteo, numero) -> {
             throw new IOException("Sin conexion");
@@ -211,7 +216,7 @@ class PanelBusquedaTest extends BaseTest {
     }
 
     @Test
-    void limpiarEliminaResultadosYCampos() throws Exception {
+    void limpiarEliminaResultadosYCampos() {
         Ventana ventana = Mockito.mock(Ventana.class);
         PanelBusqueda.PremioService premioService = (sorteo, numero) -> {
             Premio premio = new Premio();

--- a/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
+++ b/src/test/java/es/jklabs/desktop/gui/paneles/PanelBusquedaTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PanelBusquedaTest extends BaseTest {
+class PanelBusquedaTest extends BaseTest {
 
     private static void waitForBusqueda(PanelBusqueda panel) throws Exception {
         long deadline = System.currentTimeMillis() + 2000;


### PR DESCRIPTION
## 2.7.17

- Actualiza `org.apache.maven.plugins:maven-jar-plugin` de `3.5.0` a `3.5.1`.
- Amplía la cobertura de condiciones de `ResumenMouseListenerTest` para URI válidas, URL inválidas sin esquema,
  enlaces sin ruta y la restauración del navegador usado en tests.
- Sustituye la espera manual con `Thread.sleep()` en `PanelBusquedaTest` por Awaitility con sincronización del EDT,
  haciendo que los bloqueos asíncronos fallen de forma determinista al alcanzar el timeout.
- Resuelve incidencias de mantenibilidad de SonarQube en los tests mediante imports estáticos, visibilidad
  package-private y el uso de `Month.JANUARY` en fechas de prueba.